### PR TITLE
Increase precission of event scaling dialog

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1171,7 +1171,7 @@ void MainWindow::screenLockPressed(bool enable) {
 void MainWindow::scaleSelection(){
     bool ok;
     double scale = QInputDialog::getDouble(this, "Scalefactor",
-    		"Scalefactor:", 1.0, 0, 2147483647, 1, &ok);
+            "Scalefactor:", 1.0, 0, 2147483647, 17, &ok);
 	if(ok && scale>0 && Selection::instance()->selectedEvents().size()>0 && file){
     	// find minimum
     	int minTime = 2147483647;


### PR DESCRIPTION
(For my case that was been required to fix alignment of notes where is a VERY small distance that requires more precision for scaling. Sonar 1.x which I used previously allows percent-based scaling only (integer value of percent only))
This saved a lot of my time to quickly entire composition length!
For example: 37908 / 37929 = 0,999446334
