### PR TITLE
Huge fixes+improvements.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,9 @@ if(ARCH STREQUAL "x64" )
 	add_definitions(-D__ARCH64__)
 endif()
 
+# Avoid Unicode -> QString issues. 
+add_definitions(-DQT_NO_CAST_TO_ASCII)
+
 find_package(Qt5Widgets REQUIRED)
 find_package(Qt5Network REQUIRED)
 find_package(Qt5Xml     REQUIRED)

--- a/src/MidiEvent/MidiEvent.cpp
+++ b/src/MidiEvent/MidiEvent.cpp
@@ -298,12 +298,14 @@ MidiEvent *MidiEvent::loadMidiEvent(QDataStream *content, bool *ok,
 								TextEvent *textEvent = new TextEvent(channel, track);
 								textEvent->setType(tempByte);
 								int length = MidiFile::variableLengthvalue(content);
-								QByteArray array;
+								// use wchar_t because some files use Unicode.
+								wchar_t str [128] = L"";
 								for(int i = 0; i<length; i++){
 									(*content)>>tempByte;
-									array.append((char)tempByte);
+									wchar_t temp [2] = { btowc(tempByte) };
+									wcsncat(str, temp, 1);
 								}
-								textEvent->setText(QString(array));
+								textEvent->setText(QString::fromWCharArray(str));
 								*ok = true;
 								return textEvent;
 

--- a/src/MidiEvent/TextEvent.cpp
+++ b/src/MidiEvent/TextEvent.cpp
@@ -56,15 +56,22 @@ int TextEvent::line(){
 }
 
 QByteArray TextEvent::save(){
+	mbtstate_t mbs;
+	mbrlen(NULL, 0, &mbs);
 
 	QByteArray array = QByteArray();
 
 	array.append(char(0xFF));
 	array.append(_type);
 	array.append(MidiFile::writeVariableLengthValue(_text.length()));
-
-	for(int i = 0; i < _text.length(); i++){
-		array.append(_text.at(i));
+	
+	wchar_t text_wchar [128] = L"";
+	_text.toWCharArray(text_wchar);
+	
+	for(int i = 0; i < wcslen(text_wchar); i++){
+		char buffer [4];
+		wcrtomb(buffer, text_wchar[i], &mbs);
+		array.append(buffer);
 	}
 
 	return array;

--- a/src/MidiEvent/TextEvent.cpp
+++ b/src/MidiEvent/TextEvent.cpp
@@ -56,7 +56,7 @@ int TextEvent::line(){
 }
 
 QByteArray TextEvent::save(){
-	mbtstate_t mbs;
+	mbstate_t mbs;
 	mbrlen(NULL, 0, &mbs);
 
 	QByteArray array = QByteArray();

--- a/src/gui/DataEditor.cpp
+++ b/src/gui/DataEditor.cpp
@@ -55,44 +55,45 @@ QByteArray DataEditor::data(){
 void DataEditor::rebuild(){
 
 	QGridLayout *layout = dynamic_cast<QGridLayout*>(_central->layout());
+	if (layout) {
+		QList<QWidget*> widgets = _central->findChildren<QWidget *>();
+		foreach(QWidget * child, widgets) {
+			layout->removeWidget(child);
+			delete child;
+		}
 
-	QList<QWidget*> widgets = _central->findChildren<QWidget *>();
-	foreach(QWidget * child, widgets) {
-		layout->removeWidget(child);
-		delete child;
-	}
-
-	int row = 1;
-	QPushButton *plus = new QPushButton("+", _central);
-	layout->addWidget(plus, 0, 3, 1, 1);
-	plus->setMaximumWidth(50);
-	DataLineEditor *dle0 = new DataLineEditor(0, plus);
-	connect(dle0, SIGNAL(plusClicked(int)), this, SLOT(plusClicked(int)));
-
-	foreach(unsigned char c, _data){
-		QLabel *label = new QLabel("0x", _central);
-		layout->addWidget(label, row, 0, 1, 1);
-
-		QLineEdit *edit = new QLineEdit(_central);
-		edit->setInputMask("HH");
-		QString text;
-		text.sprintf("%02X", c);
-		edit->setText(text);
-		layout->addWidget(edit, row, 1, 1, 1);
-
-		QPushButton *minus = new QPushButton("-", _central);
-		minus->setMaximumWidth(50);
-		layout->addWidget(minus, row, 2, 1, 1);
-
+		int row = 1;
 		QPushButton *plus = new QPushButton("+", _central);
-		layout->addWidget(plus, row, 3, 1, 1);
+		layout->addWidget(plus, 0, 3, 1, 1);
 		plus->setMaximumWidth(50);
+		DataLineEditor *dle0 = new DataLineEditor(0, plus);
+		connect(dle0, SIGNAL(plusClicked(int)), this, SLOT(plusClicked(int)));
 
-		DataLineEditor *dle = new DataLineEditor(row, plus, minus, edit);
-		connect(dle, SIGNAL(minusClicked(int)), this, SLOT(minusClicked(int)));
-		connect(dle, SIGNAL(plusClicked(int)), this, SLOT(plusClicked(int)));
-		connect(dle, SIGNAL(dataChanged(int,unsigned char)), this, SLOT(dataChanged(int,unsigned char)));
-		row++;
+		foreach(unsigned char c, _data){
+			QLabel *label = new QLabel("0x", _central);
+			layout->addWidget(label, row, 0, 1, 1);
+
+			QLineEdit *edit = new QLineEdit(_central);
+			edit->setInputMask("HH");
+			QString text;
+			text.sprintf("%02X", c);
+			edit->setText(text);
+			layout->addWidget(edit, row, 1, 1, 1);
+
+			QPushButton *minus = new QPushButton("-", _central);
+			minus->setMaximumWidth(50);
+			layout->addWidget(minus, row, 2, 1, 1);
+
+			QPushButton *plus = new QPushButton("+", _central);
+			layout->addWidget(plus, row, 3, 1, 1);
+			plus->setMaximumWidth(50);
+
+			DataLineEditor *dle = new DataLineEditor(row, plus, minus, edit);
+			connect(dle, SIGNAL(minusClicked(int)), this, SLOT(minusClicked(int)));
+			connect(dle, SIGNAL(plusClicked(int)), this, SLOT(plusClicked(int)));
+			connect(dle, SIGNAL(dataChanged(int,unsigned char)), this, SLOT(dataChanged(int,unsigned char)));
+			row++;
+		}
 	}
 }
 

--- a/src/gui/FileLengthDialog.cpp
+++ b/src/gui/FileLengthDialog.cpp
@@ -46,8 +46,6 @@ FileLengthDialog::FileLengthDialog(MidiFile *f, QWidget *parent) :
 	layout->addWidget(acceptButton, 1, 2, 1, 1);
 	layout->setColumnStretch(1, 1);
 
-	connect(_box, SIGNAL(valueChanged(int)), acceptButton, SLOT(setFocus()));
-
 	_box->setFocus();
 	setWindowTitle("File duration");
 }

--- a/src/gui/FileLengthDialog.cpp
+++ b/src/gui/FileLengthDialog.cpp
@@ -48,7 +48,7 @@ FileLengthDialog::FileLengthDialog(MidiFile *f, QWidget *parent) :
 
 	connect(_box, SIGNAL(valueChanged(int)), acceptButton, SLOT(setFocus()));
 
-	acceptButton->setFocus();
+	_box->setFocus();
 	setWindowTitle("File duration");
 }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2500,7 +2500,7 @@ QWidget *MainWindow::setupActions(QWidget *parent){
 	QList<QKeySequence> backActionShortcuts;
 	backActionShortcuts << QKeySequence(Qt::Key_J)
 						<< QKeySequence(Qt::Key_Left);
-	backActionShortcuts->setShortcuts(backActionShortcuts);
+    backAction->setShortcuts(backActionShortcuts);
     connect(backAction, SIGNAL(triggered()), this, SLOT(back()));
     playbackMB->addAction(backAction);
 
@@ -2509,7 +2509,7 @@ QWidget *MainWindow::setupActions(QWidget *parent){
 	QList<QKeySequence> forwActionShortcuts;
 	forwActionShortcuts << QKeySequence(Qt::Key_L)
 						<< QKeySequence(Qt::Key_Right);
-	forwActionShortcuts->setShortcuts(forwActionShortcuts);
+    forwAction->setShortcuts(forwActionShortcuts);
     connect(forwAction, SIGNAL(triggered()), this, SLOT(forward()));
     playbackMB->addAction(forwAction);
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -548,13 +548,13 @@ void MainWindow::setFile(MidiFile *file){
 	connect(file,SIGNAL(recalcWidgetSize()),mw_matrixWidget,SLOT(calcSizes()));
 	connect(file->protocol(), SIGNAL(actionFinished()), this, SLOT(markEdited()));
 	connect(file->protocol(), SIGNAL(actionFinished()), eventWidget(), SLOT(reload()));
-	connect(file->protocol(), SIGNAL(actionFinished()), this, SLOT(checkEnableActionsForSeelction()));
+	connect(file->protocol(), SIGNAL(actionFinished()), this, SLOT(checkEnableActionsForSelection()));
 	mw_matrixWidget->setFile(file);
 	updateChannelMenu();
 	updateTrackMenu();
 	mw_matrixWidget->update();
 	_miscWidget->update();
-	checkEnableActionsForSeelction();
+	checkEnableActionsForSelection();
 }
 
 void MainWindow::matrixSizeChanged(int maxScrollTime, int maxScrollLine,
@@ -2901,7 +2901,7 @@ void MainWindow::setSpeed(QAction *action){
 	MidiPlayer::setSpeedScale(d);
 }
 
-void MainWindow::checkEnableActionsForSeelction(){
+void MainWindow::checkEnableActionsForSelection(){
 	bool enabled = Selection::instance()->selectedEvents().size()>0;
 	foreach(QAction *action, _activateWithSelections){
 		action->setEnabled(enabled);
@@ -2922,7 +2922,7 @@ void MainWindow::checkEnableActionsForSeelction(){
 }
 
 void MainWindow::toolChanged(){
-	checkEnableActionsForSeelction();
+	checkEnableActionsForSelection();
 	_miscWidget->update();
 	mw_matrixWidget->update();
 }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1496,7 +1496,7 @@ void MainWindow::updateTrackMenu() {
 		QVariant variant(i);
 		QAction *moveToTrackAction = new QAction(QString::number(i)+" "+file->tracks()->at(i)->name(), this);
 		moveToTrackAction->setData(variant);
-		moveToTrackAction->setShortcut(QKeySequence(Qt::Key_0+i + Qt::CTRL));
+		moveToTrackAction->setShortcut(QKeySequence(Qt::Key_0+i + Qt::ALT));
 		_moveSelectedEventsToTrackMenu->addAction(moveToTrackAction);
 	}
 
@@ -2438,7 +2438,7 @@ QWidget *MainWindow::setupActions(QWidget *parent){
 			text = "Half note";
 		} else if(i == 2){
 			text = "Quarter note";
-		} else if(i>0){
+		} else if(i > 0){
 			text = QString::number((int)qPow(2, i))+"th note";
 		}
 		QAction *a = new QAction(text, this);
@@ -2453,7 +2453,11 @@ QWidget *MainWindow::setupActions(QWidget *parent){
 
     // Playback
 	QAction *playStopAction = new QAction("PlayStop");
-	playStopAction->setShortcut(QKeySequence(Qt::Key_Space));
+	QList<QKeySequence> playStopActionShortcuts;
+	playStopActionShortcuts << QKeySequence(Qt::Key_Space)
+							<< QKeySequence(Qt::Key_K)
+							<< QKeySequence(Qt::Key_P + Qt::CTRL);
+	playStopAction->setShortcuts(playStopActionShortcuts);
 	connect(playStopAction, SIGNAL(triggered()), this, SLOT(playStop()));
 	playbackMB->addAction(playStopAction);
 
@@ -2464,7 +2468,7 @@ QWidget *MainWindow::setupActions(QWidget *parent){
 
     QAction *pauseAction = new QAction("Pause", this);
     pauseAction->setIcon(QIcon(":/run_environment/graphics/tool/pause.png"));
-	pauseAction->setShortcut(QKeySequence(Qt::Key_Space +Qt::CTRL));
+	pauseAction->setShortcut(QKeySequence(Qt::Key_Space + Qt::CTRL));
     connect(pauseAction, SIGNAL(triggered()), this, SLOT(pause()));
     playbackMB->addAction(pauseAction);
 
@@ -2483,16 +2487,29 @@ QWidget *MainWindow::setupActions(QWidget *parent){
 
 	QAction *backToBeginAction = new QAction("Back to begin", this);
     backToBeginAction->setIcon(QIcon(":/run_environment/graphics/tool/back_to_begin.png"));
+	QList<QKeySequence> backToBeginActionShortcuts;
+	backToBeginActionShortcuts << QKeySequence(Qt::Key_Home)
+							   << QKeySequence(Qt::Key_J + Qt::SHIFT)
+							   << QKeySequence(Qt::Key_Left + Qt:: SHIFT);
+	backToBeginAction->setShortcuts(backToBeginActionShortcuts);
     connect(backToBeginAction, SIGNAL(triggered()), this, SLOT(backToBegin()));
     playbackMB->addAction(backToBeginAction);
 
 	QAction *backAction = new QAction("Previous measure", this);
     backAction->setIcon(QIcon(":/run_environment/graphics/tool/back.png"));
+	QList<QKeySequence> backActionShortcuts;
+	backActionShortcuts << QKeySequence(Qt::Key_J)
+						<< QKeySequence(Qt::Key_Left);
+	backActionShortcuts->setShortcuts(backActionShortcuts);
     connect(backAction, SIGNAL(triggered()), this, SLOT(back()));
     playbackMB->addAction(backAction);
 
 	QAction *forwAction = new QAction("Next measure", this);
 	forwAction->setIcon(QIcon(":/run_environment/graphics/tool/forward.png"));
+	QList<QKeySequence> forwActionShortcuts;
+	forwActionShortcuts << QKeySequence(Qt::Key_L)
+						<< QKeySequence(Qt::Key_Right);
+	forwActionShortcuts->setShortcuts(forwActionShortcuts);
     connect(forwAction, SIGNAL(triggered()), this, SLOT(forward()));
     playbackMB->addAction(forwAction);
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -111,6 +111,9 @@ MainWindow::MainWindow(QString initFile) : QMainWindow(), _initFile(initFile) {
 #endif
 	bool alternativeStop = _settings->value("alt_stop", false).toBool();
 	MidiOutput::isAlternativePlayer = alternativeStop;
+	bool ticksOK;
+	int ticksPerQuarter = _settings->value("ticks_per_quarter", 192).toInt(&ticksOK);
+	MidiFile::defaultTimePerQuarter = ticksPerQuarter;
 	bool magnet = _settings->value("magnet", false).toBool();
 	EventTool::enableMagnet(magnet);
 
@@ -1080,6 +1083,7 @@ void MainWindow::closeEvent(QCloseEvent *event){
 	// save the current Path
 	_settings->setValue("open_path", startDirectory);
 	_settings->setValue("alt_stop", MidiOutput::isAlternativePlayer);
+	_settings->setValue("ticks_per_quarter", MidiFile::defaultTimePerQuarter);
 	_settings->setValue("screen_locked", mw_matrixWidget->screenLocked());
 	_settings->setValue("magnet", EventTool::magnetEnabled());
 

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -165,7 +165,7 @@ class MainWindow : public QMainWindow {
 
 		void setSpeed(QAction*);
 
-		void checkEnableActionsForSeelction();
+		void checkEnableActionsForSelection();
 		void toolChanged();
 		void copiedEventsChanged();
 

--- a/src/gui/MatrixWidget.cpp
+++ b/src/gui/MatrixWidget.cpp
@@ -783,7 +783,8 @@ void MatrixWidget::setFile(MidiFile *f){
 	scaleY = 1;
 
 	startTimeX = 0;
-	startLineY = 0;
+	// Roughly vertically center on Middle C. 
+	startLineY = 50;
 
 
 	connect(file->protocol(), SIGNAL(actionFinished()), this,
@@ -794,9 +795,9 @@ void MatrixWidget::setFile(MidiFile *f){
 
 	calcSizes();
 
-		// scroll down to see events
+	// scroll down to see events
 	int maxNote = -1;
-	for(int channel = 0; channel<16; channel++){
+	for(int channel = 0; channel < 16; channel++){
 
 		QMultiMap<int, MidiEvent*> *map = file->channelEvents(channel);
 
@@ -1069,48 +1070,46 @@ void MatrixWidget::wheelEvent(QWheelEvent *event){
 	Qt::KeyboardModifiers km = event->modifiers();
 	if (km) {
 		if (km == Qt::ShiftModifier) {
-			if (event->delta() > 0) {
+			if (event->delta() > 0) 
 				zoomVerIn();
-			} else {
+			else
 				zoomVerOut();
-			}
 		} else if (km == Qt::ControlModifier) {
-			if (event->delta() > 0) {
+			if (event->delta() > 0)
 				zoomHorIn();
-			} else {
+			else
 				zoomHorOut();
-			}
-		}
-	} else {
-		if (!file) return;
-		int maxTimeInFile = file->maxTime();
-		int widgetRange = endTimeX - startTimeX;
-		if (QApplication::keyboardModifiers().testFlag(Qt::AltModifier)){
+        } else if (km == Qt::AltModifier) {
+            if (!file) return;
+            int maxTimeInFile = file->maxTime();
+            int widgetRange = endTimeX - startTimeX;
 
-			int scroll = -1 * event->delta()*widgetRange / 1000;
+            int scroll = -1 * event->delta()*widgetRange / 1000;
 
-			int newStartTime = startTimeX + scroll;
+            int newStartTime = startTimeX + scroll;
 
-			scrollXChanged(newStartTime);
-			emit scrollChanged(startTimeX, maxTimeInFile - widgetRange, startLineY, NUM_LINES - (endLineY - startLineY));
-		}
-		else {
-			int newStartLineY = startLineY;
+            scrollXChanged(newStartTime);
+            emit scrollChanged(startTimeX, maxTimeInFile - widgetRange, startLineY, NUM_LINES - (endLineY - startLineY));
+        }
+    } else {
+        if (!file) return;
+        int maxTimeInFile = file->maxTime();
+        int widgetRange = endTimeX - startTimeX;
 
-			if (event->delta() > 0){
-				newStartLineY -= 3;
-			}
-			else {
-				newStartLineY += 3;
-			}
+        int newStartLineY = startLineY;
 
-			if (newStartLineY < 0){
-				newStartLineY = 0;
-			}
-			// endline too large handled in scrollYchanged()
-			scrollYChanged(newStartLineY);
-			emit scrollChanged(startTimeX, maxTimeInFile - widgetRange, startLineY, NUM_LINES - (endLineY - startLineY));
-		}
+        if (event->delta() > 0)
+            newStartLineY -= 5;
+		else
+            newStartLineY += 5;
+
+        if (newStartLineY < 0)
+            newStartLineY = 0;
+
+        // endline too large handled in scrollYchanged()
+        scrollYChanged(newStartLineY);
+        emit scrollChanged(startTimeX, maxTimeInFile - widgetRange, startLineY, NUM_LINES - (endLineY - startLineY));
+
 	}
 }
 

--- a/src/gui/MatrixWidget.cpp
+++ b/src/gui/MatrixWidget.cpp
@@ -46,7 +46,7 @@ MatrixWidget::MatrixWidget(QWidget *parent) : PaintWidget(parent) {
 
 	screen_locked = false;
 	startTimeX = 0;
-	startLineY = 0;
+	startLineY = 50;
 	endTimeX = 0;
 	endLineY = 0;
 	file = 0;

--- a/src/gui/MidiSettingsWidget.cpp
+++ b/src/gui/MidiSettingsWidget.cpp
@@ -64,9 +64,9 @@ AdditionalMidiSettingsWidget::AdditionalMidiSettingsWidget(QSettings *settings, 
 
 	layout->addWidget(separator(), 5, 0, 1, 6);
 
-	layout->addWidget(new QLabel("Start command:", this), 6, 0, 1, 1);
+	layout->addWidget(new QLabel("Start command:", this), 6, 0, 1, 2);
 	startCmd = new QLineEdit(this);
-	layout->addWidget(startCmd, 6, 1, 1, 5);
+	layout->addWidget(startCmd, 6, 1, 1, 4);
 
 	QWidget *startCmdInfo = createInfoBox("The start command can be used to start additional software components (e.g. Midi synthesizers) each time, MidiEditor is started. You can see the output of the started software / script in the field below.");
 	layout->addWidget(startCmdInfo, 7, 0, 1, 6);

--- a/src/gui/MidiSettingsWidget.cpp
+++ b/src/gui/MidiSettingsWidget.cpp
@@ -27,8 +27,10 @@
 #include <QCheckBox>
 #include <QSettings>
 #include <QTextEdit>
+#include <QSpinBox>
 #include "../midi/MidiOutput.h"
 #include "../midi/MidiInput.h"
+#include "../midi/MidiFile.h"
 #include "../Terminal.h"
 
 AdditionalMidiSettingsWidget::AdditionalMidiSettingsWidget(QSettings *settings, QWidget *parent) : SettingsWidget("Additional Midi Settings", parent) {
@@ -37,33 +39,50 @@ AdditionalMidiSettingsWidget::AdditionalMidiSettingsWidget(QSettings *settings, 
 
 	QGridLayout *layout = new QGridLayout(this);
 	setLayout(layout);
+	
+	layout->addWidget(new QLabel("Default ticks per quarter note:", this), 0, 0, 1, 2);
+	_tpqBox = new QSpinBox(this);
+	_tpqBox->setMinimum(1);
+	_tpqBox->setMaximum(1024);
+	_tpqBox->setValue(MidiFile::defaultTimePerQuarter);
+	connect(_tpqBox, SIGNAL(valueChanged(int)), this, SLOT(setDefaultTimePerQuarter(int)));
+	layout->addWidget(_tpqBox, 0, 2, 1, 4);
+	
+    QWidget *tpqInfo = createInfoBox("Note: There aren't many reasons to change this. MIDI files have a resolution for how many ticks can fit in a quarter note. Higher values = more detail. Lower values may be required for compatibility. Only affects new files.");
+	layout->addWidget(tpqInfo, 1, 0, 1, 6);
+	
+	layout->addWidget(separator(), 2, 0, 1, 6);
 
 	_alternativePlayerModeBox = new QCheckBox("Manually stop notes", this);
 	_alternativePlayerModeBox->setChecked(MidiOutput::isAlternativePlayer);
 
 	connect(_alternativePlayerModeBox, SIGNAL(toggled(bool)), this, SLOT(manualModeToggled(bool)));
-	layout->addWidget(_alternativePlayerModeBox, 0, 0, 1, 6);
+	layout->addWidget(_alternativePlayerModeBox, 3, 0, 1, 6);
 
 	QWidget *playerModeInfo = createInfoBox("Note: the above option should not be enabled in general. It is only required if the stop button does not stop playback as expected (e.g. when some notes are not stopped correctly).");
-	layout->addWidget(playerModeInfo, 1, 0, 1, 6);
+	layout->addWidget(playerModeInfo, 4, 0, 1, 6);
 
-	layout->addWidget(separator(), 2, 0, 1, 6);
+	layout->addWidget(separator(), 5, 0, 1, 6);
 
-	layout->addWidget(new QLabel("Start command:", this), 3, 0, 1, 1);
+	layout->addWidget(new QLabel("Start command:", this), 6, 0, 1, 1);
 	startCmd = new QLineEdit(this);
-	layout->addWidget(startCmd, 3, 1, 1, 5);
+	layout->addWidget(startCmd, 6, 1, 1, 5);
 
 	QWidget *startCmdInfo = createInfoBox("The start command can be used to start additional software components (e.g. Midi synthesizers) each time, MidiEditor is started. You can see the output of the started software / script in the field below.");
-	layout->addWidget(startCmdInfo, 4, 0, 1, 6);
+	layout->addWidget(startCmdInfo, 7, 0, 1, 6);
 
-	layout->addWidget(Terminal::terminal()->console(), 5, 0, 1, 6);
+	layout->addWidget(Terminal::terminal()->console(), 8, 0, 1, 6);
 
 	startCmd->setText(_settings->value("start_cmd", "").toString());
-	layout->setRowStretch(5, 1);
+	layout->setRowStretch(3, 1);
 }
 
 void AdditionalMidiSettingsWidget::manualModeToggled(bool enable){
 	MidiOutput::isAlternativePlayer = enable;
+}
+
+void AdditionalMidiSettingsWidget::setDefaultTimePerQuarter(int value) {
+	MidiFile::defaultTimePerQuarter = value;
 }
 
 bool AdditionalMidiSettingsWidget::accept(){

--- a/src/gui/MidiSettingsWidget.cpp
+++ b/src/gui/MidiSettingsWidget.cpp
@@ -48,7 +48,7 @@ AdditionalMidiSettingsWidget::AdditionalMidiSettingsWidget(QSettings *settings, 
 	connect(_tpqBox, SIGNAL(valueChanged(int)), this, SLOT(setDefaultTimePerQuarter(int)));
 	layout->addWidget(_tpqBox, 0, 2, 1, 4);
 	
-    QWidget *tpqInfo = createInfoBox("Note: There aren't many reasons to change this. MIDI files have a resolution for how many ticks can fit in a quarter note. Higher values = more detail. Lower values may be required for compatibility. Only affects new files.");
+	QWidget *tpqInfo = createInfoBox("Note: There aren't many reasons to change this. MIDI files have a resolution for how many ticks can fit in a quarter note. Higher values = more detail. Lower values may be required for compatibility. Only affects new files.");
 	layout->addWidget(tpqInfo, 1, 0, 1, 6);
 	
 	layout->addWidget(separator(), 2, 0, 1, 6);
@@ -66,7 +66,7 @@ AdditionalMidiSettingsWidget::AdditionalMidiSettingsWidget(QSettings *settings, 
 
 	layout->addWidget(new QLabel("Start command:", this), 6, 0, 1, 2);
 	startCmd = new QLineEdit(this);
-	layout->addWidget(startCmd, 6, 1, 1, 4);
+	layout->addWidget(startCmd, 6, 2, 1, 4);
 
 	QWidget *startCmdInfo = createInfoBox("The start command can be used to start additional software components (e.g. Midi synthesizers) each time, MidiEditor is started. You can see the output of the started software / script in the field below.");
 	layout->addWidget(startCmdInfo, 7, 0, 1, 6);

--- a/src/gui/MidiSettingsWidget.h
+++ b/src/gui/MidiSettingsWidget.h
@@ -26,6 +26,7 @@ class QListWidget;
 class QListWidgetItem;
 class QLineEdit;
 class QCheckBox;
+class QSpinBox;
 class QSettings;
 
 class AdditionalMidiSettingsWidget : public SettingsWidget {
@@ -38,11 +39,13 @@ class AdditionalMidiSettingsWidget : public SettingsWidget {
 
 	public slots:
 		void manualModeToggled(bool enable);
+		void setDefaultTimePerQuarter(int value);
 
 	private:
 		QCheckBox *_alternativePlayerModeBox;
 		QSettings *_settings;
 		QLineEdit *startCmd;
+		QSpinBox *_tpqBox;
 
 };
 

--- a/src/gui/MiscWidget.cpp
+++ b/src/gui/MiscWidget.cpp
@@ -127,13 +127,13 @@ void MiscWidget::paintEvent(QPaintEvent *event){
             NoteOnEvent *noteOn = dynamic_cast<NoteOnEvent*>(event);
             if(noteOn){
                 velocity=noteOn->velocity();
-            }
 
-            if(velocity>0){
-                int h = (height()*velocity)/128;
-                painter->setBrush(*c);
-                painter->setPen(Qt::lightGray);
-                painter->drawRoundedRect(event->x()-LEFT_BORDER_MATRIX_WIDGET, height()-h, WIDTH, h, 1, 1);
+                if(velocity>0){
+                    int h = (height()*velocity)/128;
+                    painter->setBrush(*c);
+                    painter->setPen(Qt::lightGray);
+                    painter->drawRoundedRect(event->x()-LEFT_BORDER_MATRIX_WIDGET, height()-h, WIDTH, h, 1, 1);
+                }
             }
         }
 
@@ -150,22 +150,22 @@ void MiscWidget::paintEvent(QPaintEvent *event){
 					continue;
 				}
 
-
 				int velocity = 0;
 				NoteOnEvent *noteOn = dynamic_cast<NoteOnEvent*>(event);
 
 				if(noteOn && noteOn->midiTime()>=matrixWidget->minVisibleMidiTime() && noteOn->midiTime()<=matrixWidget->maxVisibleMidiTime()){
 					velocity=noteOn->velocity();
-				}
-				if(velocity>0){
-					int h = (height()*velocity)/128;
-					if(edit_mode==SINGLE_MODE && dragging){
-						h+=(dragY-mouseY);
-					}
-					painter->setBrush(Qt::darkBlue);
-					painter->setPen(Qt::lightGray);
-					painter->drawRoundedRect(event->x()-LEFT_BORDER_MATRIX_WIDGET, height()-h, WIDTH, h, 1, 1);
-				}
+
+                    if(velocity>0){
+                        int h = (height()*velocity)/128;
+                        if(edit_mode==SINGLE_MODE && dragging){
+                            h+=(dragY-mouseY);
+                        }
+                        painter->setBrush(Qt::darkBlue);
+                        painter->setPen(Qt::lightGray);
+                        painter->drawRoundedRect(event->x()-LEFT_BORDER_MATRIX_WIDGET, height()-h, WIDTH, h, 1, 1);
+                    }
+                }
 			}
 		}
     }
@@ -290,12 +290,13 @@ void MiscWidget::mouseMoveEvent(QMouseEvent *event){
                     NoteOnEvent *noteOn = dynamic_cast<NoteOnEvent*>(event);
                     if(noteOn){
                         velocity=noteOn->velocity();
-                    }
-                    if(velocity>0){
-                        int h = (height()*velocity)/128;
-                        if(mouseInRect(event->x()-LEFT_BORDER_MATRIX_WIDGET, height()-h-5, WIDTH, 10)){
-                            above = true;
-                            break;
+
+                        if(velocity>0){
+                            int h = (height()*velocity)/128;
+                            if(mouseInRect(event->x()-LEFT_BORDER_MATRIX_WIDGET, height()-h-5, WIDTH, 10)){
+                                above = true;
+                                break;
+                            }
                         }
                     }
                 }
@@ -497,14 +498,16 @@ void MiscWidget::mouseReleaseEvent(QMouseEvent *event){
                     int dV = 127*dX/height();
 					foreach(MidiEvent *event, Selection::instance()->selectedEvents()){
                         NoteOnEvent *noteOn = dynamic_cast<NoteOnEvent*>(event);
-                        int v = dV+noteOn->velocity();
-                        if(v>127){
-                            v = 127;
+                        if (noteOn) {
+                            int v = dV+noteOn->velocity();
+                            if(v>127){
+                                v = 127;
+                            }
+                            if(v<0){
+                                v=0;
+                            }
+                            noteOn->setVelocity(v);
                         }
-                        if(v<0){
-                            v=0;
-                        }
-                        noteOn->setVelocity(v);
                     }
 
                     matrixWidget->midiFile()->protocol()->endAction();

--- a/src/gui/TransposeDialog.cpp
+++ b/src/gui/TransposeDialog.cpp
@@ -31,9 +31,10 @@ TransposeDialog::TransposeDialog(QList<NoteOnEvent*> toTranspose, MidiFile *file
 
 	QLabel *text = new QLabel("Number of semitones: ", this);
 	_valueBox = new QSpinBox(this);
-	_valueBox->setMinimum(1);
+	_valueBox->setMinimum(0);
 	_valueBox->setMaximum(2147483647);
 	_valueBox->setValue(0);
+	_valueBox->setFocus();
 
 
 	QButtonGroup *group = new QButtonGroup();

--- a/src/gui/TransposeDialog.cpp
+++ b/src/gui/TransposeDialog.cpp
@@ -34,8 +34,6 @@ TransposeDialog::TransposeDialog(QList<NoteOnEvent*> toTranspose, MidiFile *file
 	_valueBox->setMinimum(0);
 	_valueBox->setMaximum(2147483647);
 	_valueBox->setValue(0);
-	_valueBox->setFocus();
-
 
 	QButtonGroup *group = new QButtonGroup();
 	_up = new QRadioButton("up", this);
@@ -58,6 +56,7 @@ TransposeDialog::TransposeDialog(QList<NoteOnEvent*> toTranspose, MidiFile *file
 	layout->addWidget(acceptButton, 2, 2, 1, 1);
 	layout->setColumnStretch(1, 1);
 
+	_valueBox->setFocus();
 	_toTranspose = toTranspose;
 	_file = file;
 }

--- a/src/midi/MidiChannel.cpp
+++ b/src/midi/MidiChannel.cpp
@@ -42,22 +42,22 @@ QColor *MidiChannel::colorByChannelNumber(int number){
 	QColor *color;
 
 	switch(number){
-		case 0: { color = new QColor(241, 214, 107, 255);break; }
-		case 1: { color =  new QColor(205, 241, 142, 255);break; }
-		case 2: { color = new QColor(107, 241, 142, 255);break; }
+        case 0: { color = new QColor(241, 70, 57, 255);break; }
+        case 1: { color =  new QColor(205, 221, 0, 255);break; }
+        case 2: { color = new QColor(70, 241, 50, 255);break; }
 		case 3: { color = new QColor(107, 241, 231, 255);break; }
-		case 4: { color =  new QColor(200, 236, 255, 255);break; }
+        case 4: { color =  new QColor(127, 67, 255, 255);break; }
 		case 5: { color = new QColor(241, 107, 200, 255);break; }
 		case 6: { color = new QColor(170, 212, 170, 255);break; }
-		case 7: { color =  new QColor(212, 204, 170, 255);break; }
-		case 8: { color = new QColor(238, 233, 138, 255);break; }
-		case 9: { color = new QColor(243, 94, 54, 255);break; }
-		case 10: { color = new QColor(255, 145, 26, 255);break; }
-		case 11: { color = new QColor(181, 132, 80, 255);break; }
+		case 7: { color =  new QColor(222, 202, 170, 255);break; }
+		case 8: { color = new QColor(241, 201, 20, 255);break; }
+        case 9: { color = new QColor(80, 80, 80, 255);break; }
+		case 10: { color = new QColor(127, 0, 30, 255);break; }
+		case 11: { color = new QColor(171, 132, 80, 255);break; }
 		case 12: { color =  new QColor(102, 162, 37, 255);break; }
 		case 13: { color = new QColor(241, 164, 107, 255);break; }
-		case 14: { color = new QColor(222, 213, 66, 255);break; }
-		case 15: { color = new QColor(202, 222, 66, 255);break; }
+		case 14: { color = new QColor(127, 50, 127, 255);break; }
+		case 15: { color = new QColor(50, 127, 127, 255);break; }
 		default: { color = new QColor(50, 50, 255, 255); break; }
 	}
 

--- a/src/midi/MidiFile.cpp
+++ b/src/midi/MidiFile.cpp
@@ -38,7 +38,7 @@
 
 #include <QtCore/qmath.h>
 
-int defaultTimePerQuarter = 192;
+int MidiFile::defaultTimePerQuarter = 192;
 
 MidiFile::MidiFile(){
 	_saved = true;

--- a/src/midi/MidiFile.cpp
+++ b/src/midi/MidiFile.cpp
@@ -38,6 +38,8 @@
 
 #include <QtCore/qmath.h>
 
+int defaultTimePerQuarter = 192;
+
 MidiFile::MidiFile(){
 	_saved = true;
 	midiTicks = 0;
@@ -50,7 +52,7 @@ MidiFile::MidiFile(){
 		channels[i] = new MidiChannel(this, i);
 	}
 
-	timePerQuarter = 192;
+	timePerQuarter = MidiFile::defaultTimePerQuarter;
 	_midiFormat = 1;
 
 	_tracks = new QList<MidiTrack*>();

--- a/src/midi/MidiFile.h
+++ b/src/midi/MidiFile.h
@@ -92,6 +92,7 @@ class MidiFile : public QObject, public ProtocolEntry {
 
 		static int variableLengthvalue(QDataStream *content);
 		static QByteArray writeVariableLengthValue(int value);
+		static int defaultTimePerQuarter;
 
 		void registerCopiedTrack(MidiTrack *source, MidiTrack *destination, MidiFile *fileFrom);
 		MidiTrack *getPasteTrack(MidiTrack *source, MidiFile *fileFrom);

--- a/src/midi/MidiTrack.cpp
+++ b/src/midi/MidiTrack.cpp
@@ -77,22 +77,22 @@ void MidiTrack::setNumber(int number){
 	_number = number;
 
 	switch((number-1)%16){
-		case 0: { _color = new QColor(241, 214, 107, 255);break; }
-		case 1: { _color =  new QColor(205, 241, 142, 255);break; }
-		case 2: { _color = new QColor(107, 241, 142, 255);break; }
+		case 0: { _color = new QColor(241, 70, 57, 255);break; }
+		case 1: { _color =  new QColor(205, 221, 0, 255);break; }
+		case 2: { _color = new QColor(70, 241, 50, 255);break; }
 		case 3: { _color = new QColor(107, 241, 231, 255);break; }
-		case 4: { _color =  new QColor(200, 236, 255, 255);break; }
+		case 4: { _color =  new QColor(127, 67, 255, 255);break; }
 		case 5: { _color = new QColor(241, 107, 200, 255);break; }
 		case 6: { _color = new QColor(170, 212, 170, 255);break; }
-		case 7: { _color =  new QColor(212, 204, 170, 255);break; }
-		case 8: { _color = new QColor(238, 233, 138, 255);break; }
-		case 9: { _color = new QColor(243, 94, 54, 255);break; }
-		case 10: { _color = new QColor(255, 145, 26, 255);break; }
-		case 11: { _color = new QColor(181, 132, 80, 255);break; }
+		case 7: { _color =  new QColor(222, 202, 170, 255);break; }
+		case 8: { _color = new QColor(241, 201, 20, 255);break; }
+		case 9: { _color = new QColor(80, 80, 80, 255);break; }
+		case 10: { _color = new QColor(127, 0, 30, 255);break; }
+		case 11: { _color = new QColor(171, 132, 80, 255);break; }
 		case 12: { _color =  new QColor(102, 162, 37, 255);break; }
 		case 13: { _color = new QColor(241, 164, 107, 255);break; }
-		case 14: { _color = new QColor(222, 213, 66, 255);break; }
-		case 15: { _color = new QColor(202, 222, 66, 255);break; }
+		case 14: { _color = new QColor(127, 50, 127, 255);break; }
+		case 15: { _color = new QColor(50, 127, 127, 255);break; }
 		default: { _color = new QColor(50, 50, 255, 255); break; }
 	}
 

--- a/src/midi/SenderThread.cpp
+++ b/src/midi/SenderThread.cpp
@@ -41,5 +41,5 @@ void SenderThread::enqueue(MidiEvent *event){
 	if (dynamic_cast <NoteOnEvent*>(event)) 
 		_eventQueue->push_back(event);
 	else 
-		_eventQueut->push_front(event);
+		_eventQueue->push_front(event);
 }

--- a/src/midi/SenderThread.cpp
+++ b/src/midi/SenderThread.cpp
@@ -18,6 +18,7 @@
 
 #include "SenderThread.h"
 #include "../MidiEvent/MidiEvent.h"
+#include "../MidiEvent/NoteOnEvent.h"
 
 SenderThread::SenderThread() {
 	_eventQueue = new QQueue<MidiEvent*>;
@@ -36,5 +37,9 @@ void SenderThread::run(){
 }
 
 void SenderThread::enqueue(MidiEvent *event){
-	_eventQueue->push_back(event);
+	// Notes go last to prevent confliction with control change events.
+	if (dynamic_cast <NoteOnEvent*>(event)) 
+		_eventQueue->push_back(event);
+	else 
+		_eventQueut->push_front(event);
 }

--- a/src/tool/EventTool.cpp
+++ b/src/tool/EventTool.cpp
@@ -177,9 +177,11 @@ void EventTool::copyAction(){
 			OnEvent *onEv = dynamic_cast<OnEvent*>(ev);
 			if(onEv){
 				OffEvent *offEv = dynamic_cast<OffEvent*>(onEv->offEvent()->copy());
+                if (offEv) {
 				offEv->setOnEvent(onEv);
 				copiedEvents->append(offEv);
 			}
+		}
 		}
 		_mainWindow->copiedEventsChanged();
 	}
@@ -211,8 +213,10 @@ void EventTool::pasteAction(){
 		OnEvent *onEv = dynamic_cast<OnEvent*>(ev);
 		if(onEv){
 			OffEvent *offEv = dynamic_cast<OffEvent*>(onEv->offEvent()->copy());
+            if (offEv) {
 			offEv->setOnEvent(onEv);
 			copiedCopiedEvents.append(offEv);
+            }
 		}
 	}
 


### PR DESCRIPTION
* Fixed program changes on the same tick as events (#4) by putting `NoteOnEvent`s to the end of the event queue, and everything else to the beginning of the queue. That way, notes are always emitted after Program Change Events.
* Fixed Unicode bug (most, if not all, of #5) by using `wchar_t` instead of `char` to properly support Unicode. 
* Fixed dragging-out-of-bounds issues (#6) by adding min/max checks. I know this can be simplified.
* Fixed the crash while dragging the velocity bars on non-note events (#7) by adding in a forgotten `dynamic_cast` check. 
  * Added a few extra `dynamic_cast` checks to be safe.
* Changed most of the colors to be more distinct. Feel free to mess with them, they aren't very pretty.
* Fixed Alt+Scroll not scrolling horizontally.
* Vertical scrolling is faster, and roughly matches horizontal speed. My finger hurts a lot less now. 😄 
* When creating/opening a file, the editor roughly scrolls to Middle C instead of the top of the keyboard.
* Added/changed a few key shortcuts:
  * YouTube-style J-K-L controls. 
  * Shift + prev. measure or Home goes to beginning.
  * "Change Track" was changed from Ctrl+Track# to Alt+Track# to prevent conflicts with Ctrl+0 to reset zoom. 
* Added "Default ticks per quarter note" option in Advanced MIDI settings. This affects new files. 
  * Hopefully, I could add a "Change ticks per quarter note" menu item in the future. 
* Transpose Dialog starts at 0 and focuses the textbox.
* File Length Dialog no longer spams focus on the Accept button.

Hopefully it works right. I have been messing with the code and I thought that to make things easier, I would copy over my changes and document them. I diffed the folders and they seem to be roughly the same. 

Unfortunately, I am godawful at Git and I am not 100% sure how to squash commits, so it isn't the prettiest. 
