### PR TITLE
Fix Fix for #4

### DIFF
--- a/src/midi/SenderThread.cpp
+++ b/src/midi/SenderThread.cpp
@@ -19,27 +19,37 @@
 #include "SenderThread.h"
 #include "../MidiEvent/MidiEvent.h"
 #include "../MidiEvent/NoteOnEvent.h"
+#include "../MidiEvent/OffEvent.h"
 
 SenderThread::SenderThread() {
 	_eventQueue = new QQueue<MidiEvent*>;
+	_noteQueue = new QQueue<MidiEvent*>;
 }
 
 void SenderThread::run(){
 
 	while(true) {
+		// First, send the misc events, such as control change and program change events.
 		while(!_eventQueue->isEmpty()){
 			// send command
 			MidiOutput::sendEnqueuedCommand(_eventQueue->head()->save());
 			_eventQueue->pop_front();
+		}
+		// Now send the note events.
+		while(!_noteQueue->isEmpty()){
+			// send command
+			MidiOutput::sendEnqueuedCommand(_noteQueue->head()->save());
+			_noteQueue->pop_front();
 		}
 		msleep(1);
 	}
 }
 
 void SenderThread::enqueue(MidiEvent *event){
-	// Notes go last to prevent confliction with control change events.
-	if (dynamic_cast <NoteOnEvent*>(event)) 
-		_eventQueue->push_back(event);
+	// If it is a NoteOnEvent or an OffEvent, we put it in _noteQueue. 
+	if (dynamic_cast <NoteOnEvent*>(event) || dynamic_cast <OffEvent*>(event)) 
+		_noteQueue->push_back(event);
+	// Otherwise, it goes into _eventQueue.
 	else 
-		_eventQueue->push_front(event);
+		_eventQueue->push_back(event);
 }

--- a/src/midi/SenderThread.h
+++ b/src/midi/SenderThread.h
@@ -33,6 +33,7 @@ class SenderThread : public QThread {
 
 	private:
 		QQueue<MidiEvent*> *_eventQueue;
+		QQueue<MidiEvent*> *_noteQueue;
 
 };
 


### PR DESCRIPTION
One effect of my fix for #4 was that it reversed the orders of the control change events.

This reversed LSB and MSB, and midi output drivers misbehave when their control change events aren't in the right order.

Unfortunately, that means we have to do everything twice. ☹️ 